### PR TITLE
Generate unique_id with organization id

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.27.1.1
+ - Add organization id to generate unique_id because there are conflicts when there is a multitenant.
+ ❗ Be careful, this change this fix will make all verifications in production no longer valid because the `unique_id` will be generated differently ❗
+
 ## v0.27.1.0
  - Upgrade to use Ruby 3.1.3, but be compatible with > 3.0
  - Upgrade to Decidim v0.27.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-file_authorization_handler (0.27.1.0)
+    decidim-file_authorization_handler (0.27.1.1)
       decidim (~> 0.27.1)
       decidim-admin (~> 0.27.1)
       rails (>= 5.2)

--- a/app/services/file_authorization_handler.rb
+++ b/app/services/file_authorization_handler.rb
@@ -41,7 +41,7 @@ class FileAuthorizationHandler < Decidim::AuthorizationHandler
   end
 
   def unique_id
-    census_for_user&.id_document
+    Digest::SHA256.hexdigest("#{census_for_user&.id_document}-#{organization.id}-#{Rails.application.secrets.secret_key_base}")
   end
 
   def census_for_user

--- a/lib/decidim/file_authorization_handler/version.rb
+++ b/lib/decidim/file_authorization_handler/version.rb
@@ -7,6 +7,6 @@ module Decidim
     # Uses the latest matching Decidim version for
     # - major, minor and patch
     # - the optional extra number is related to this module's patches
-    VERSION = "#{DECIDIM_VERSION}.0".freeze
+    VERSION = "#{DECIDIM_VERSION}.1".freeze
   end
 end

--- a/spec/services/decidim/file_authorization_handler/file_authorization_handler_spec.rb
+++ b/spec/services/decidim/file_authorization_handler/file_authorization_handler_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe FileAuthorizationHandler do
     described_class.new(user:, id_document: dni, birthdate: date)
                    .with_context(current_organization: organization)
   end
+  let!(:unique_id) do
+    Digest::SHA256.hexdigest("#{handler.census_for_user&.id_document}-#{organization.id}-#{Rails.application.secrets.secret_key_base}")
+  end
 
   let(:census_datum) do
     create(:census_datum, id_document: encoded_dni,
@@ -36,6 +39,10 @@ RSpec.describe FileAuthorizationHandler do
     census_datum
     expect(handler.valid?).to be true
     expect(handler.metadata).to eq(birthdate: "1990/11/21")
+  end
+
+  it "generates unique_id correctly" do
+    expect(unique_id).to eq(handler.unique_id)
   end
 
   it "works when no current_organization context is provided (but the user is)" do


### PR DESCRIPTION
#### :tophat: What? Why?
- Add organization id to generate unique_id because there are conflicts when there is a multitenant.
- Bump module version to 0.27.1.1

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [x] Add tests
- [ ] Another subtask
