### PR TITLE
Backport "Generate unique_id with organization id" to 0.25-stable

### DIFF
--- a/app/services/file_authorization_handler.rb
+++ b/app/services/file_authorization_handler.rb
@@ -35,7 +35,7 @@ class FileAuthorizationHandler < Decidim::AuthorizationHandler
   end
 
   def unique_id
-    census_for_user&.id_document
+    Digest::SHA256.hexdigest("#{census_for_user&.id_document}-#{organization.id}-#{Rails.application.secrets.secret_key_base}")
   end
 
   def census_for_user

--- a/spec/services/decidim/file_authorization_handler/file_authorization_handler_spec.rb
+++ b/spec/services/decidim/file_authorization_handler/file_authorization_handler_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe FileAuthorizationHandler do
                    .with_context(current_organization: organization)
   end
 
+  let!(:unique_id) do
+    Digest::SHA256.hexdigest("#{handler.census_for_user&.id_document}-#{organization.id}-#{Rails.application.secrets.secret_key_base}")
+  end
+
   let(:census_datum) do
     FactoryBot.create(:census_datum, id_document: encoded_dni,
                                      birthdate: date,
@@ -36,6 +40,10 @@ RSpec.describe FileAuthorizationHandler do
     census_datum
     expect(handler.valid?).to be true
     expect(handler.metadata).to eq(birthdate: "1990/11/21")
+  end
+
+  it "generates unique_id correctly" do
+    expect(unique_id).to eq(handler.unique_id)
   end
 
   it "works when no current_organization context is provided (but the user is)" do


### PR DESCRIPTION
#### :tophat: What? Why?
Add organization id to generate unique_id because there are conflicts when there is a multitenant.
