### PR TITLE
FIX: ignore `CensusDatum#extras` if not set

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## v0.27.1.3
+ - FIX: ignore CensusDatum#extras if not set.
+
 ## v0.27.1.2
  - Add missing translations about first login.
 

--- a/app/services/file_authorization_handler.rb
+++ b/app/services/file_authorization_handler.rb
@@ -16,7 +16,7 @@ class FileAuthorizationHandler < Decidim::AuthorizationHandler
   def metadata
     @metadata ||= begin
       meta = { birthdate: census_for_user&.birthdate&.strftime("%Y/%m/%d") }
-      census_for_user.extras.each_pair do |key, value|
+      census_for_user&.extras&.each_pair do |key, value|
         meta[key.to_sym] = value
       end
       meta

--- a/lib/decidim/file_authorization_handler/version.rb
+++ b/lib/decidim/file_authorization_handler/version.rb
@@ -7,6 +7,6 @@ module Decidim
     # Uses the latest matching Decidim version for
     # - major, minor and patch
     # - the optional extra number is related to this module's patches
-    VERSION = "#{DECIDIM_VERSION}.2".freeze
+    VERSION = "#{DECIDIM_VERSION}.3".freeze
   end
 end

--- a/spec/factories/census_datum.rb
+++ b/spec/factories/census_datum.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     id_document { "123456789A" }
     birthdate { 20.years.ago }
     organization
-    extras { {} }
+    extras { nil }
 
     trait :with_extras do
       extras { { district: "123456789", postal_code: "ABCDEFGHIJK", segment_1: Random.hex } }

--- a/spec/services/decidim/file_authorization_handler/file_authorization_handler_spec.rb
+++ b/spec/services/decidim/file_authorization_handler/file_authorization_handler_spec.rb
@@ -15,42 +15,44 @@ RSpec.describe FileAuthorizationHandler do
     Digest::SHA256.hexdigest("#{handler.census_for_user&.id_document}-#{organization.id}-#{Rails.application.secrets.secret_key_base}")
   end
 
-  let(:census_datum) do
-    create(:census_datum, id_document: encoded_dni,
-                          birthdate: date,
-                          organization:)
-  end
+  context "without extras in CensusDatum" do
+    let(:census_datum) do
+      create(:census_datum, id_document: encoded_dni,
+                            birthdate: date,
+                            organization:)
+    end
 
-  it "validates against database" do
-    expect(handler.valid?).to be false
-    census_datum
-    expect(handler.valid?).to be true
-  end
+    it "validates against database" do
+      expect(handler.valid?).to be false
+      census_datum
+      expect(handler.valid?).to be true
+    end
 
-  it "normalizes the id document" do
-    census_datum
-    normalizer =
-      described_class.new(user:, id_document: "12-34-a", birthdate: date)
-                     .with_context(current_organization: organization)
-    expect(normalizer.valid?).to be true
-  end
+    it "normalizes the id document" do
+      census_datum
+      normalizer =
+        described_class.new(user:, id_document: "12-34-a", birthdate: date)
+                       .with_context(current_organization: organization)
+      expect(normalizer.valid?).to be true
+    end
 
-  it "generates birthdate metadata" do
-    census_datum
-    expect(handler.valid?).to be true
-    expect(handler.metadata).to eq(birthdate: "1990/11/21")
-  end
+    it "generates birthdate metadata" do
+      census_datum
+      expect(handler.valid?).to be true
+      expect(handler.metadata).to eq(birthdate: "1990/11/21")
+    end
 
-  it "generates unique_id correctly" do
-    expect(unique_id).to eq(handler.unique_id)
-  end
+    it "generates unique_id correctly" do
+      expect(unique_id).to eq(handler.unique_id)
+    end
 
-  it "works when no current_organization context is provided (but the user is)" do
-    census_datum
-    contextless_handler = described_class.new(user:,
-                                              id_document: dni,
-                                              birthdate: date)
-    expect(contextless_handler.valid?).to be true
+    it "works when no current_organization context is provided (but the user is)" do
+      census_datum
+      contextless_handler = described_class.new(user:,
+                                                id_document: dni,
+                                                birthdate: date)
+      expect(contextless_handler.valid?).to be true
+    end
   end
 
   context "with extras in CensusDatum" do


### PR DESCRIPTION
#### :tophat: What? Why?
When the participants verify, if the uploaded CSV had no extra fields than `document_id` and `birthdate`, then the `extras` attribute was `nil` and the application crashed.
This PR solves it.


#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [x] Add tests
- [ ] Another subtask
