### PR TITLE
Add parameter in query

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## v0.27.1.4
+ - FIX: add compatibilty cross older Ruby versions by adding the hash value in the parameter.
+
 ## v0.27.1.3
  - FIX: ignore CensusDatum#extras if not set.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-file_authorization_handler (0.27.1.2)
+    decidim-file_authorization_handler (0.27.1.4)
       decidim (~> 0.27.1)
       decidim-admin (~> 0.27.1)
       rails (>= 5.2)

--- a/app/jobs/decidim/file_authorization_handler/remove_duplicates_job.rb
+++ b/app/jobs/decidim/file_authorization_handler/remove_duplicates_job.rb
@@ -5,15 +5,17 @@ module Decidim
     class RemoveDuplicatesJob < ApplicationJob
       queue_as :default
 
+      # rubocop:disable Style/HashSyntax
       def perform(organization)
         duplicated_census(organization).pluck(:id_document).each do |id_document|
           CensusDatum.inside(organization)
-                     .where(id_document:)
+                     .where(id_document: id_document)
                      .order(id: :desc)
                      .all[1..]
                      .each(&:delete)
         end
       end
+      # rubocop:enable Style/HashSyntax
 
       private
 

--- a/lib/decidim/file_authorization_handler/version.rb
+++ b/lib/decidim/file_authorization_handler/version.rb
@@ -7,6 +7,6 @@ module Decidim
     # Uses the latest matching Decidim version for
     # - major, minor and patch
     # - the optional extra number is related to this module's patches
-    VERSION = "#{DECIDIM_VERSION}.3".freeze
+    VERSION = "#{DECIDIM_VERSION}.4".freeze
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
-  Add compatibilty cross older Ruby versions by adding the hash value in the parameter.
- Update module version

to be compatible with decidim-initiatives it must be compatible with Ruby 3.0.2.