### PR TITLE
When organization is nil, unique_id caused an exception. 

### DIFF
--- a/app/services/file_authorization_handler.rb
+++ b/app/services/file_authorization_handler.rb
@@ -41,6 +41,7 @@ class FileAuthorizationHandler < Decidim::AuthorizationHandler
   end
 
   def unique_id
+    return nil unless organization
     Digest::SHA256.hexdigest("#{census_for_user&.id_document}-#{organization.id}-#{Rails.application.secrets.secret_key_base}")
   end
 


### PR DESCRIPTION
This was a problem with new impersonations. Now it returns nil.

#### :tophat: What? Why?
Using «Gestiona una nova participant» button in impersonations list caused a null pointer error when this handler was active.


#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [ ] Add tests
- [ ] Another subtask
