### PR TITLE
Fix when organization is nil, unique_id causes an exception

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## v0.27.1.5
+ - FIX: When organization is nil, unique_id causes an exception.
+
 ## v0.27.1.4
  - FIX: add compatibilty cross older Ruby versions by adding the hash value in the parameter.
 

--- a/app/services/file_authorization_handler.rb
+++ b/app/services/file_authorization_handler.rb
@@ -41,6 +41,8 @@ class FileAuthorizationHandler < Decidim::AuthorizationHandler
   end
 
   def unique_id
+    return nil unless organization
+
     Digest::SHA256.hexdigest("#{census_for_user&.id_document}-#{organization.id}-#{Rails.application.secrets.secret_key_base}")
   end
 

--- a/lib/decidim/file_authorization_handler/version.rb
+++ b/lib/decidim/file_authorization_handler/version.rb
@@ -7,6 +7,6 @@ module Decidim
     # Uses the latest matching Decidim version for
     # - major, minor and patch
     # - the optional extra number is related to this module's patches
-    VERSION = "#{DECIDIM_VERSION}.4".freeze
+    VERSION = "#{DECIDIM_VERSION}.5".freeze
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
The problem appears with impersonations. See https://github.com/CodiTramuntana/decidim-file_authorization_handler/pull/18 .

#### :pushpin: Related Issues
- Related to https://github.com/CodiTramuntana/decidim-file_authorization_handler/pull/18
