### PR TITLE
Backport "fix frozen string literal error in handler name" to v0.25

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## v0.25.2.4
+- Backport fix frozen string literal error with handler name.
+
 ## v0.25.2.3
 - Backport fixes with unique_id
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-file_authorization_handler (0.25.2.3)
+    decidim-file_authorization_handler (0.25.2.4)
       decidim (~> 0.25.2)
       decidim-admin (~> 0.25.2)
       rails (>= 5.2)
@@ -796,4 +796,4 @@ DEPENDENCIES
   rubocop (~> 0.92.0)
 
 BUNDLED WITH
-   2.3.4
+   2.3.6

--- a/app/services/file_authorization_handler.rb
+++ b/app/services/file_authorization_handler.rb
@@ -20,7 +20,7 @@ class FileAuthorizationHandler < Decidim::AuthorizationHandler
   # This is required in new 0.8.4 version of decicim
   # however, there's a bug and this doesn't work
   def handler_name
-    "file_authorization_handler"
+    +"file_authorization_handler"
   end
 
   # Checks if the id_document belongs to the census

--- a/lib/decidim/file_authorization_handler/version.rb
+++ b/lib/decidim/file_authorization_handler/version.rb
@@ -7,6 +7,6 @@ module Decidim
     # Uses the latest matching Decidim version for
     # - major, minor and patch
     # - the optional extra number is related to this module's patches
-    VERSION = "#{DECIDIM_VERSION}.3"
+    VERSION = "#{DECIDIM_VERSION}.4"
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Backport https://github.com/CodiTramuntana/decidim-file_authorization_handler/pull/6 to `release-0.25_stable`.