### PR TITLE
Adapt handler to initiatives

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## v0.27.1.6
+ - FIX: Add a hack in `file_authorization_handler` order to sign initiatives because in decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb send to handler_for a param named document_number.
+
 ## v0.27.1.5
  - FIX: When organization is nil, unique_id causes an exception.
 

--- a/app/services/file_authorization_handler.rb
+++ b/app/services/file_authorization_handler.rb
@@ -5,6 +5,9 @@
 class FileAuthorizationHandler < Decidim::AuthorizationHandler
   # This is the input (from the user) to validate against
   attribute :id_document, String
+  # This is a hack in order to sign initiatives because in decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
+  # send to handler_for a param named document_number.
+  attribute :document_number, String
   attribute :birthdate, Decidim::Attributes::LocalizedDate
 
   # This is the validation to perform
@@ -50,7 +53,7 @@ class FileAuthorizationHandler < Decidim::AuthorizationHandler
     return unless organization
 
     @census_for_user ||= Decidim::FileAuthorizationHandler::CensusDatum
-                         .search_id_document(organization, id_document)
+                         .search_id_document(organization, id_document || document_number)
   end
 
   def organization

--- a/lib/decidim/file_authorization_handler/version.rb
+++ b/lib/decidim/file_authorization_handler/version.rb
@@ -7,6 +7,6 @@ module Decidim
     # Uses the latest matching Decidim version for
     # - major, minor and patch
     # - the optional extra number is related to this module's patches
-    VERSION = "#{DECIDIM_VERSION}.5".freeze
+    VERSION = "#{DECIDIM_VERSION}.6".freeze
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Initiatives do a `handler_for` with  `document_number` field but in the module, the field is named `id_document`.

this PR adds the  `:document_number` attribute as a kind of synonym of `id_document` to keep compatibility with existing authorizations and also be compatible with `decidim-initiatives`.
