### PR TITLE
Remove failed inflectors

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## v0.30.1.1
+- Remove inflectors about census because there are conflicts with Decidim core authorizations
+
 ## v0.30.1
 - Upgrade to Decidim 0.30.1
 - Set Ruby version to 3.3.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-file_authorization_handler (0.30.1)
-      decidim (~> 0.30.1)
-      decidim-admin (~> 0.30.1)
-    decidim-file_authorization_handler (0.30.1.0)
+    decidim-file_authorization_handler (0.30.1.1)
       decidim (~> 0.30.1)
       decidim-admin (~> 0.30.1)
 

--- a/lib/decidim/file_authorization_handler/engine.rb
+++ b/lib/decidim/file_authorization_handler/engine.rb
@@ -6,12 +6,6 @@ module Decidim
     class Engine < ::Rails::Engine
       isolate_namespace Decidim::FileAuthorizationHandler
 
-      initializer "decidim_census.add_irregular_inflection" do |_app|
-        ActiveSupport::Inflector.inflections(:en) do |inflect|
-          inflect.irregular "census", "census"
-        end
-      end
-
       initializer "decidim_census.add_authorization_handlers" do |_app|
         Decidim::Verifications.register_workflow(:file_authorization_handler) do |workflow|
           workflow.form = "FileAuthorizationHandler"

--- a/lib/decidim/file_authorization_handler/version.rb
+++ b/lib/decidim/file_authorization_handler/version.rb
@@ -7,6 +7,6 @@ module Decidim
     # Uses the latest matching Decidim version for
     # - major, minor and patch
     # - the optional extra number is related to this module's patches
-    VERSION = "#{DECIDIM_VERSION}.0".freeze
+    VERSION = "#{DECIDIM_VERSION}.1".freeze
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Inflectors of census cause a problem with decidim core routes and csv_census.

 