### PR TITLE
Backport "Remove fail inflectors" to release/0.28-stable

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -25,7 +25,7 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
 
       - name: Recover Ruby dependency cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./vendor/bundle
           key: ${{ runner.OS }}-rubydeps-${{ hashFiles('Gemfile.lock') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:11
+        image: postgres:16
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready
@@ -26,11 +26,12 @@ jobs:
         env:
           POSTGRES_PASSWORD: postgres
     env:
+      DISABLE_SPRING: 1
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -39,7 +40,7 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
 
       - name: Recover Ruby dependency cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ./vendor/bundle
           key: ${{ runner.OS }}-rubydeps-${{ hashFiles('Gemfile.lock') }}
@@ -72,4 +73,4 @@ jobs:
           timeout_minutes: 10
           max_attempts: 3
           retry_on: error
-          command: bundle exec rake --backtrace -t
+          command: DISABLE_SPRING=1 bundle exec rake --backtrace -t

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## v0.28.2.1
+  - Remove inflectors about census because there are conflicts with Decidim core authorizations
+
 ## v0.28.2.0
  - Upgrade to Decidim 0.28
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-file_authorization_handler (0.28.2.0)
+    decidim-file_authorization_handler (0.28.2.1)
       decidim (~> 0.28.2)
       decidim-admin (~> 0.28.2)
       rails (>= 5.2)

--- a/lib/decidim/file_authorization_handler/engine.rb
+++ b/lib/decidim/file_authorization_handler/engine.rb
@@ -6,12 +6,6 @@ module Decidim
     class Engine < ::Rails::Engine
       isolate_namespace Decidim::FileAuthorizationHandler
 
-      initializer "decidim_census.add_irregular_inflection" do |_app|
-        ActiveSupport::Inflector.inflections(:en) do |inflect|
-          inflect.irregular "census", "census"
-        end
-      end
-
       initializer "decidim_census.add_authorization_handlers" do |_app|
         Decidim::Verifications.register_workflow(:file_authorization_handler) do |workflow|
           workflow.form = "FileAuthorizationHandler"

--- a/lib/decidim/file_authorization_handler/version.rb
+++ b/lib/decidim/file_authorization_handler/version.rb
@@ -7,6 +7,6 @@ module Decidim
     # Uses the latest matching Decidim version for
     # - major, minor and patch
     # - the optional extra number is related to this module's patches
-    VERSION = "#{DECIDIM_VERSION}.0".freeze
+    VERSION = "#{DECIDIM_VERSION}.1".freeze
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Backport "Remove fail inflectors" to release/0.28-stable
